### PR TITLE
Add GNOME 3.8 support

### DIFF
--- a/icon-hider@kalnitsky.org/metadata.json
+++ b/icon-hider@kalnitsky.org/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.4", "3.6"],
+    "shell-version": ["3.4", "3.6", "3.7.92", "3.8"],
     "uuid": "icon-hider@kalnitsky.org",
     "name": "Icon Hider",
     "description": "Show/Hide icons from top panel",


### PR DESCRIPTION
Extension correctly work in GNOME 3.8, so I just update `shell-version` in `metadata.json`.
