### PR TITLE
Support GNOME 3.32

### DIFF
--- a/icon-hider@kalnitsky.org/metadata.json
+++ b/icon-hider@kalnitsky.org/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.26", "3.28", "3.30"],
+    "shell-version": ["3.32"],
     "uuid": "icon-hider@kalnitsky.org",
     "name": "Icon Hider",
     "description": "Show/Hide icons from top panel",


### PR DESCRIPTION
This change updates the use of JavaScript classes to be compatible with
ES6 and GNOME Shell 3.32's behavior. Additionally, it adds a hack to
prevent calling `destroy` on an already destroyed indicator instance.