### PR TITLE
Fix compatability with GNOME 3.36

### DIFF
--- a/icon-hider@kalnitsky.org/extension.js
+++ b/icon-hider@kalnitsky.org/extension.js
@@ -159,7 +159,7 @@ class Extension {
         // call `this._reloadSettings` if settings or tray icons was changed
         let reload = Lang.bind(this, this._reloadSettings);
 
-        this._settingsId = this._settings.connect('changed::', reload);
+        this._settingsId = this._settings.connect('changed', reload);
         this._trayAddedId = this._traymanager.connect('tray-icon-added', reload);
         this._trayRemovedId = this._traymanager.connect('tray-icon-removed', reload);
 


### PR DESCRIPTION
Fixes the error that I was getting on GNOME 3.36:
`Error: No signal 'changed::' on object 'GSettings'`

This should ~~close~~ #47, although the error there seems unrelated to this fix, so I dunno. I wasn't able to reproduce that one, but it seems like some sort of duplicate extension conflict or something. Either way, this fix makes the extension work properly for me.